### PR TITLE
Упростил команду для тестов

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "./node_modules/.bin/yaspeller ./episodes"
+    "test": "yaspeller ./episodes"
   },
   "dependencies": {
     "yaspeller": "^2.8.2"


### PR DESCRIPTION
Когда ты делаешь что-то через npm-скрипт в PATH дописывается каталог node_modules и его можно не указывать явно.
