### PR TITLE
Добавил возможность трансформации markdown в простой текст

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
   "scripts": {
-    "test": "yaspeller ./episodes"
+    "test": "yaspeller ./episodes",
+    "demark": "demarked ./episodes/episode-$NUM.md"
   },
   "dependencies": {
+    "demarked": "^0.0.3",
     "yaspeller": "^2.8.2"
   }
 }


### PR DESCRIPTION
Запилил простенький дешаблонизатор поверх [marked](https://www.npmjs.com/package/marked) и подключил его как npm-скрипт. Это должно решить первую часть задачи в #93.

Как пользоваться:

``` bash
NUM=29 npm run demark
```

Возьмёт файл эпизода №29, прогонит его через [demarked](https://www.npmjs.com/package/demarked) и выведет в stdout.

Если хочется сохранить в файл, то делаем так:

``` bash
NUM=29 npm run demark -- -o /tmp/episode-29.demarked.txt
```

Обращаю внимание на `--` перед ключом `-o`.
